### PR TITLE
Factory closure binding order

### DIFF
--- a/Swifjection/Classes/Bindings/Bindings.swift
+++ b/Swifjection/Classes/Bindings/Bindings.swift
@@ -23,7 +23,7 @@ open class Bindings {
         bindings[typeName] = ObjectBinding(withObject: object)
     }
 
-    public func bind(closure: @escaping ((Injecting) -> Any), toType type: Any.Type) {
+    public func bind(type: Any.Type, with closure: @escaping ((Injecting) -> Any)) {
         let typeName = "\(type)"
         bindings[typeName] = ClosureBinding(withClosure: closure)
     }

--- a/Swifjection/Classes/Bindings/BindingsSpec.swift
+++ b/Swifjection/Classes/Bindings/BindingsSpec.swift
@@ -112,7 +112,7 @@ class BindingsSpec: QuickSpec {
                 closure = { injector in
                     return ClassConformingToProtocol()
                 }
-                bindings.bind(closure: closure, toType: ClassConformingToProtocol.self)
+                bindings.bind(type: ClassConformingToProtocol.self, with: closure)
             }
             
             it("should add one binding") {
@@ -122,7 +122,7 @@ class BindingsSpec: QuickSpec {
             context("when binding same closure to another type") {
                 
                 beforeEach {
-                    bindings.bind(closure: closure, toType: EmptySwiftProtocol.self)
+                    bindings.bind(type: EmptySwiftProtocol.self, with: closure)
                 }
                 
                 it("should add another binding") {
@@ -141,7 +141,7 @@ class BindingsSpec: QuickSpec {
                         otherClosureCalled = true
                         return ClassConformingToProtocol()
                     }
-                    bindings.bind(closure: otherClosure, toType: ClassConformingToProtocol.self)
+                    bindings.bind(type: ClassConformingToProtocol.self, with: otherClosure)
                 }
                 
                 afterEach {
@@ -347,10 +347,10 @@ class BindingsSpec: QuickSpec {
             beforeEach {
                 object = InjectableClass()
                 bindings.bind(object: object, toType: InjectableClass.self)
-                bindings.bind(closure: { injector in
+                bindings.bind(type: InjectableClass.self) { injector in
                     closureCalled = true
                     return object
-                }, toType: InjectableClass.self)
+                }
                 bindings.bindSingleton(forType: InjectableClass.self)
             }
             

--- a/Swifjection/Classes/SwifjectionIntegrationTests.swift
+++ b/Swifjection/Classes/SwifjectionIntegrationTests.swift
@@ -40,10 +40,10 @@ class SwifjectionIntegrationTests: QuickSpec {
             
             beforeEach {
                 object = EmptySwiftClass()
-                bindings.bind(closure: { injector in
+                bindings.bind(type: EmptySwiftClass.self) { injector in
                     closureCalled = true
                     return object
-                }, toType: EmptySwiftClass.self)
+                }
                 
                 returnedObject = injector.getObject(withType: EmptySwiftClass.self)
             }
@@ -127,10 +127,10 @@ class SwifjectionIntegrationTests: QuickSpec {
                 
                 beforeEach {
                     object = InjectableClass()
-                    bindings.bind(closure: { injector in
+                    bindings.bind(type: InjectableClass.self) { injector in
                         closureCalled = true
                         return object
-                        }, toType: InjectableClass.self)
+                    }
                     
                     returnedObject = injector.getObject(withType: InjectableClassProtocol.self)
                 }

--- a/Swifjection/Classes/SwifjectorSpec.swift
+++ b/Swifjection/Classes/SwifjectorSpec.swift
@@ -120,25 +120,25 @@ class InjectingSpec: QuickSpec {
                         injectableObject?.injectDependencies(injector: injector)
                         injectableObjCObject?.injectDependencies(injector: injector)
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: EmptySwiftProtocol.self) { (injector: Injecting) -> AnyObject in
                             return objectConformingToProtocol!
-                        }, toType: EmptySwiftProtocol.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: EmptySwiftClass.self) { (injector: Injecting) -> AnyObject in
                             return emptySwiftObject!
-                        }, toType: EmptySwiftClass.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: InjectableClass.self) { (injector: Injecting) -> AnyObject in
                             return injectableObject!
-                        }, toType: InjectableClass.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: InjectableObjCClass.self) { (injector: Injecting) -> AnyObject in
                             return injectableObjCObject!
-                        }, toType: InjectableObjCClass.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: ObjCClass.self) { (injector: Injecting) -> AnyObject in
                             return objCObject!
-                        }, toType: ObjCClass.self)
+                        }
 
                         objectWithDependencies = ClassWithDependencies(injector: injector)
                         objectWithDependencies?.injectDependencies(injector: injector)
@@ -177,29 +177,29 @@ class InjectingSpec: QuickSpec {
                 context("closure bindings with new instances") {
 
                     beforeEach {
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: EmptySwiftProtocol.self) { (injector: Injecting) -> AnyObject in
                             return ClassConformingToProtocol()
-                        }, toType: EmptySwiftProtocol.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: EmptySwiftClass.self) { (injector: Injecting) -> AnyObject in
                             return EmptySwiftClass()
-                        }, toType: EmptySwiftClass.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: InjectableClass.self) { (injector: Injecting) -> AnyObject in
                             let injectableObject = InjectableClass()
                             injectableObject.injectDependencies(injector: injector)
                             return injectableObject
-                        }, toType: InjectableClass.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: InjectableObjCClass.self) { (injector: Injecting) -> AnyObject in
                             let injectableObjCObject = InjectableObjCClass()
                             injectableObjCObject.injectDependencies(injector: injector)
                             return injectableObjCObject
-                        }, toType: InjectableObjCClass.self)
+                        }
 
-                        bindings.bind(closure: { (injector: Injecting) -> AnyObject in
+                        bindings.bind(type: ObjCClass.self) { (injector: Injecting) -> AnyObject in
                             return ObjCClass()
-                        }, toType: ObjCClass.self)
+                        }
 
                         objectWithDependencies = ClassWithDependencies(injector: injector)
                         objectWithDependencies?.injectDependencies(injector: injector)


### PR DESCRIPTION
Moved closure argument to be the last argument of `bind` function. That approach allows to omit argument name and have closure defined after closing parenthesis. Helps with inlining and code readability.