### PR TITLE
Add support for SPM build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,7 @@ DerivedData
 # Bundler
 .bundle
 
+# SPM
+.build
+
 Pods/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+import PackageDescription
+
+let package = Package(
+    name: "Swifjection",
+    exclude: [
+       "Example",
+       "_Pods.xcodeproj",
+       "Swifjection/Classes/SwifjectionIntegrationTests.swift", 
+	    "Swifjection/Classes/SwifjectorSpec.swift",
+	    "Swifjection/Classes/Bindings/BindingsSpec.swift",
+	    "Swifjection/Classes/Bindings/ClosureBindingSpec.swift",
+	    "Swifjection/Classes/Bindings/ObjectBindingSpec.swift",
+	    "Swifjection/Classes/Bindings/SingletonBindingSpec.swift",
+	    "Swifjection/Classes/Bindings/TypeBindingSpec.swift"
+	 ]
+)


### PR DESCRIPTION
This change adds a support for `Swift Package Manager`. So you can build `Swifjection` with:

> swift build

EDITED: It looks like there is a task for this: https://github.com/ApplauseOSS/Swifjection/projects/1