### PR TITLE
Bug/30 Crash fetching not mapped type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Swifjection Changelog
 
-## [Unreleased]
+## [0.6.0] - 26.01.2017
 ### Added:
 * Continuous Integration setup with build status badge in README
 * Code documentation
 * Swift Package manifest
-* CHANGELOG
+* `CHANGELOG`
 
 ### Changed:
+* Resolved exception when `Swifjection` couldn't create instance of singleton object 
 * Changed order of closure binding function parameters:
 
   ```Swift

--- a/Sources/Swifjection/Classes/Bindings/Bindings.swift
+++ b/Sources/Swifjection/Classes/Bindings/Bindings.swift
@@ -53,7 +53,7 @@ open class Bindings {
      */
     public func findBinding(type: Any.Type) -> Any? {
         let typeName = "\(type)"
-        if let injector = self.injector, let binding = bindings[typeName] {
+        if let injector = injector, let binding = bindings[typeName] {
             return binding.getObject(withInjector: injector)
         }
         return nil

--- a/Sources/Swifjection/Classes/Bindings/ClosureBinding.swift
+++ b/Sources/Swifjection/Classes/Bindings/ClosureBinding.swift
@@ -48,6 +48,6 @@ public class ClosureBinding: Binding {
      - Returns: Object created using the `closure`.
      */
     public func getObject(withInjector injector: Injecting) -> Any? {
-        return self.closure(injector)
+        return closure(injector)
     }    
 }

--- a/Sources/Swifjection/Classes/Bindings/SingletonBinding.swift
+++ b/Sources/Swifjection/Classes/Bindings/SingletonBinding.swift
@@ -56,7 +56,7 @@ public class SingletonBinding: Binding {
      - Returns: An singleton instance of `type` provided during initialization of this binding.
      */
     public func getObject(withInjector injector: Injecting) -> Any? {
-        if self.instance == nil {
+        if instance == nil {
             if let type = self.type as? Injectable.Type {
                 let instance = type.init(injector: injector)
                 instance?.injectDependencies(injector: injector)

--- a/Sources/Swifjection/Classes/Bindings/SingletonBinding.swift
+++ b/Sources/Swifjection/Classes/Bindings/SingletonBinding.swift
@@ -64,7 +64,7 @@ public class SingletonBinding: Binding {
             } else if let type = self.type as? NSObject.Type {
                 self.instance = type.init()
             }
-        }
-        return self.instance!
+        }        
+        return self.instance
     }
 }

--- a/Sources/Swifjection/Classes/Bindings/SingletonBindingSpec.swift
+++ b/Sources/Swifjection/Classes/Bindings/SingletonBindingSpec.swift
@@ -145,9 +145,27 @@ class SingletonBindingSpec: QuickSpec {
                 }
                 
             }
-            
         }
         
+        context("created with not Injectable, nor NSObject type") {
+            
+            beforeEach {
+                closureBinding = SingletonBinding(withType: EmptySwiftClass.self)
+            }
+            
+            describe("getObject") {
+                
+                var returnedObject: Any?
+                
+                beforeEach {
+                    returnedObject = closureBinding?.getObject(withInjector: FakeInjector())
+                }
+                
+                it("should return nil") {
+                    expect(returnedObject).to(beNil())
+                }
+            }
+        }
     }
     
 }

--- a/Sources/Swifjection/Classes/Bindings/TypeBinding.swift
+++ b/Sources/Swifjection/Classes/Bindings/TypeBinding.swift
@@ -37,7 +37,7 @@ class TypeBinding: Binding {
      - Returns: An initialized `TypeBinding` object.
      */
     public init<T>(withType type: T.Type) {
-        self.objectCreationClosure = { injector in
+        objectCreationClosure = { injector in
             return injector.getObject(withType: type)
         }
     }
@@ -50,7 +50,7 @@ class TypeBinding: Binding {
      - Returns: An initialized `TypeBinding` object.
      */
     public init<T>(withType type: T.Type) where T: Injectable {
-        self.objectCreationClosure = { injector in
+        objectCreationClosure = { injector in
             return injector.getObject(withType: type)
         }
     }
@@ -63,7 +63,7 @@ class TypeBinding: Binding {
      - Returns: An initialized `TypeBinding` object.
      */
     public init<T>(withType type: T.Type) where T: NSObject {
-        self.objectCreationClosure = { injector in
+        objectCreationClosure = { injector in
             return injector.getObject(withType: type)
         }
     }
@@ -76,7 +76,7 @@ class TypeBinding: Binding {
      - Returns: An initialized `TypeBinding` object.
      */
     public init<T>(withType type: T.Type) where T: NSObject, T: Injectable {
-        self.objectCreationClosure = { injector in
+        objectCreationClosure = { injector in
             return injector.getObject(withType: type)
         }
     }
@@ -89,6 +89,6 @@ class TypeBinding: Binding {
      - Returns: Object of `type` created using the `injector`, or nil.
      */
     func getObject(withInjector injector: Injecting) -> Any? {
-        return self.objectCreationClosure(injector)
+        return objectCreationClosure(injector)
     }
 }

--- a/Swifjection.podspec
+++ b/Swifjection.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Swifjection'
-  s.version          = '0.5.0'
+  s.version          = '0.6.0'
   s.summary          = 'Dependency Injection library for Swift'
   s.description      = <<-DESC
 Lightweight and simplistic dependency injection framework written in Swift for Swift .


### PR DESCRIPTION
Bug: #30 

What's up:
- removed forced unwrapped optional in singleton binding 
- removed unnecessary `self.` usage
- bumped version to `0.6.0`
