### PR TITLE
Added missing version link in Changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@
   - Object binding
   - Closure binding
 
-[Unreleased]: https://github.com/ApplauseOSS/Swifjection/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/ApplauseOSS/Swifjection/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/ApplauseOSS/Swifjection/compare/0.5.1...0.6.0
 [0.5.0]: https://github.com/ApplauseOSS/Swifjection/compare/v0.4.1...0.5.0
 [0.4.1]: https://github.com/ApplauseOSS/Swifjection/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/ApplauseOSS/Swifjection/compare/v0.3.1...v0.4.0


### PR DESCRIPTION
What's up:
- updated `CHANGELOG` to correctly link to 0.6.0 version