### PR TITLE
Added subscript implementation for injecting objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Swifjection Changelog
 
+## [Unreleased]
+### Added
+* Subscript implementation for injecting objects using:
+
+  ```Swift
+  let myObject = injector[MyClass.self]
+  let myOhterObject: MyClass? = injector[MyClass.self] as MyClass // This requires explicit casting
+  ```
+
 ## [0.6.0] - 26.01.2017
 ### Added:
 * Continuous Integration setup with build status badge in README
@@ -8,7 +17,7 @@
 * `CHANGELOG`
 
 ### Changed:
-* Resolved exception when `Swifjection` couldn't create instance of singleton object 
+* Resolved exception when `Swifjection` couldn't create instance of singleton object
 * Changed order of closure binding function parameters:
 
   ```Swift

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Nimble (5.1.1)
-  - Quick (0.10.0)
-  - Swifjection (0.5.0)
+  - Nimble (6.0.0)
+  - Quick (1.0.0)
+  - Swifjection (0.6.0)
 
 DEPENDENCIES:
   - Nimble
@@ -13,9 +13,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
-  Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
-  Swifjection: 0614fc542a7009b1f99684031d4bf3b9ee2008aa
+  Nimble: 8fb9b4b34c535b2f32f52c6b9852d6f02d48610b
+  Quick: 8024e4a47e6cc03a9d5245ef0948264fc6d27cff
+  Swifjection: 646e6894215df1e285a7302b0da84ee1e7cda041
 
 PODFILE CHECKSUM: 60d64b0fbabf954b03972ce4ed30ea4722d7aa72
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ As in any other DI framework you can setup mapping for objects you would like to
       object.setup() // do some additional setup
       return object
   }
-  
+
   ```
 
 * **instance to type mapping**
@@ -102,7 +102,23 @@ The biggest advantage of using Swifjection as your Dependency Injection framewor
 
 Othewrwise injector will return nil.
 
-## Fetching dependencies
+## Creating objects using `Swifjector`
+
+`Injecting` protocol provides default implementation of `getObject(withType:)` generic function, which returns object of `T` type, passed as an argument.
+
+```Swift
+let object = injector.getObject(withType: MyClass.self)
+let otherObject: MyClass? = injector.getObject(withType: MyClass.self) // This does not require any casting
+```
+
+In addition to this function, we've implemented `subscript` function, which takes the type as an argument, but is not generic, so may require explicit casting of returned object in some cases:
+
+```Swift
+let object = injector[MyClass.self]
+let otherObject: MyClass? = injector[MyClass.self] as MyClass // This requires explicit casting
+```
+
+## Fetching object's dependencies
 
 Each class or struct which can be injected and/or has dependencies to be injected should conform to `Injectable` protocol:
 

--- a/Sources/Swifjection/Classes/Bindings/Bindings.swift
+++ b/Sources/Swifjection/Classes/Bindings/Bindings.swift
@@ -26,13 +26,6 @@ import Foundation
 
 open class Bindings {
     /**
-     The `injector` used for creating new instances of objects in certain bindings.
-     
-     Injector will be passed to `getObject(withInjector injector: Injecting)` function.
-     */
-    weak var injector: Injecting?
-    
-    /**
      Dictionary of `Binding` objects bound to type names converted to `String`.
      */
     var bindings: [String: Binding] = [:]
@@ -43,21 +36,6 @@ open class Bindings {
      - Returns: An initialized `Bindings` object.
      */
     public init() { }
-    
-    /**
-     Looks for the `Binding` assigned to provided `type`, and returns object returned by calling `getObject(withInjector injector: Injecting)`, or `nil` if no binding found.
-     
-     - Parameter type: Function will search for `Binding` object assigned to this `type`.
-     
-     - Returns: Object returned from binding, or `nil`.
-     */
-    public func findBinding(type: Any.Type) -> Any? {
-        let typeName = "\(type)"
-        if let injector = injector, let binding = bindings[typeName] {
-            return binding.getObject(withInjector: injector)
-        }
-        return nil
-    }
 
     /**
      Binds provided `object` using `ObjectBinding` to the `type`.
@@ -146,5 +124,16 @@ open class Bindings {
     public func bind<T>(type boundType: T.Type, toType type: Any.Type) where T: NSObject, T: Injectable {
         let typeName = "\(type)"
         bindings[typeName] = TypeBinding(withType: boundType)
+    }
+    
+    public subscript(type: Any.Type) -> Binding? {
+        get {
+            let typeName = "\(type)"
+            return bindings[typeName]
+        }
+        set {
+            let typeName = "\(type)"
+            bindings[typeName] = newValue
+        }
     }
 }

--- a/Sources/Swifjection/Classes/Bindings/BindingsSpec.swift
+++ b/Sources/Swifjection/Classes/Bindings/BindingsSpec.swift
@@ -7,12 +7,9 @@ class BindingsSpec: QuickSpec {
     override func spec() {
         
         var bindings: Bindings!
-        var injector: FakeInjector!
         
         beforeEach {
-            injector = FakeInjector()
             bindings = Bindings()
-            bindings.injector = injector
         }
         
         describe("bind(object:, toType:)") {
@@ -383,22 +380,22 @@ class BindingsSpec: QuickSpec {
             
         }
         
-        describe("findBinding(type:)") {
+        describe("subscript(type:)") {
             
             context("when binding for the type exists") {
                 
-                var object: InjectableClass?
+                var objectBinding: Binding?
                 var returnedObject: Any?
                 
                 beforeEach {
-                    object = InjectableClass()
-                    let objectBinding = ObjectBinding(withObject: object!)
-                    bindings.bindings = ["\(InjectableClass.self)": objectBinding]
-                    returnedObject = bindings.findBinding(type: InjectableClass.self)
+                    let object = InjectableClass()
+                    objectBinding = ObjectBinding(withObject: object)
+                    bindings.bindings = ["\(InjectableClass.self)": objectBinding!]
+                    returnedObject = bindings[InjectableClass.self]
                 }
                 
                 it("should return proper object") {
-                    expect(returnedObject).to(beIdenticalTo(object))
+                    expect(returnedObject).to(beIdenticalTo(objectBinding))
                 }
                 
             }
@@ -408,7 +405,7 @@ class BindingsSpec: QuickSpec {
                 var returnedObject: Any?
                 
                 beforeEach {
-                    returnedObject = bindings.findBinding(type: InjectableClass.self)
+                    returnedObject = bindings[InjectableClass.self]
                 }
                 
                 it("should return nil") {

--- a/Sources/Swifjection/Classes/Protocols/Injecting+CreatingObjects.swift
+++ b/Sources/Swifjection/Classes/Protocols/Injecting+CreatingObjects.swift
@@ -23,21 +23,21 @@ import Foundation
 
 public extension Injecting {
     public func getObject<T>(withType type: T.Type) -> T? where T: Any {
-        if let object = bindings.findBinding(type: type) as? T {
+        if let object = bindings[type]?.getObject(withInjector: self) as? T {
             return object
         }
         return nil
     }
     
     public func getObject<T>(withType type: T.Type) -> T? where T: NSObject {
-        if let object = bindings.findBinding(type: type) as? T {
+        if let object = bindings[type]?.getObject(withInjector: self) as? T {
             return object
         }
         return type.init()
     }
     
     public func getObject<T>(withType type: T.Type) -> T? where T: Injectable {
-        if let object = bindings.findBinding(type: type) as? T {
+        if let object = bindings[type]?.getObject(withInjector: self) as? T {
             return object
         }
         if let object = type.init(injector: self) {
@@ -48,7 +48,35 @@ public extension Injecting {
     }
     
     public func getObject<T>(withType type: T.Type) -> T? where T: NSObject, T: Injectable {
-        if let object = bindings.findBinding(type: type) as? T {
+        if let object = bindings[type]?.getObject(withInjector: self) as? T {
+            return object
+        }
+        if let object = type.init(injector: self) {
+            object.injectDependencies(injector: self)
+            return object
+        }
+        return nil
+    }
+    
+    public subscript(type: Any.Type) -> Any? {
+        if let object = bindings[type]?.getObject(withInjector: self) {
+            return object
+        }
+        return nil
+    }
+    
+    public subscript(type: NSObject.Type) -> NSObject? {
+        if let object = bindings[type]?.getObject(withInjector: self) as? NSObject {
+            if let injectable = object as? Injectable {
+                injectable.injectDependencies(injector: self)
+            }
+            return object
+        }
+        return type.init()
+    }
+    
+    public subscript(type: Injectable.Type) -> Injectable? {
+        if let object = bindings[type]?.getObject(withInjector: self) as? Injectable {
             return object
         }
         if let object = type.init(injector: self) {

--- a/Sources/Swifjection/Classes/SwifjectionIntegrationTests.swift
+++ b/Sources/Swifjection/Classes/SwifjectionIntegrationTests.swift
@@ -20,16 +20,35 @@ class SwifjectionIntegrationTests: QuickSpec {
             
             var object: EmptySwiftClass!
             
-            beforeEach {
-                object = EmptySwiftClass()
-                bindings.bind(object: object, toType: EmptySwiftClass.self)
+            context("using getObject function", { 
                 
-                returnedObject = injector.getObject(withType: EmptySwiftClass.self)
-            }
+                beforeEach {
+                    object = EmptySwiftClass()
+                    bindings.bind(object: object, toType: EmptySwiftClass.self)
+                    
+                    returnedObject = injector.getObject(withType: EmptySwiftClass.self)
+                }
+                
+                it("should return bound object") {
+                    expect(returnedObject).to(beIdenticalTo(object))
+                }
+
+            });
             
-            it("should return bound object") {
-                expect(returnedObject).to(beIdenticalTo(object))
-            }
+            context("using subscript", {
+                
+                beforeEach {
+                    object = EmptySwiftClass()
+                    bindings.bind(object: object, toType: EmptySwiftClass.self)
+                    
+                    returnedObject = injector[EmptySwiftClass.self] as AnyObject
+                }
+                
+                it("should return bound object") {
+                    expect(returnedObject).to(beIdenticalTo(object))
+                }
+                
+            });
             
         }
         

--- a/Sources/Swifjection/Classes/Swifjector.swift
+++ b/Sources/Swifjection/Classes/Swifjector.swift
@@ -38,6 +38,5 @@ public class Swifjector: Injecting {
      */
     required public init(bindings: Bindings) {
         self.bindings = bindings
-        self.bindings.injector = self
     }
 }

--- a/Sources/Swifjection/Classes/SwifjectorSpec.swift
+++ b/Sources/Swifjection/Classes/SwifjectorSpec.swift
@@ -13,8 +13,428 @@ class InjectingSpec: QuickSpec {
             bindings = Bindings()
             injector = Swifjector(bindings: bindings)
         }
+        
+        describe("getObject(withType:)") {
+            
+            context("without any bindings") {
+                
+                it("should not return object conforming to protocol") {
+                    expect(injector.getObject(withType: EmptySwiftProtocol.self)).to(beNil())
+                }
+                
+                it("should not return empty swift object") {
+                    expect(injector.getObject(withType: EmptySwiftClass.self)).to(beNil())
+                }
+                
+                it("should return injectable object") {
+                    expect(injector.getObject(withType: InjectableClass.self)).notTo(beNil())
+                }
+                
+                it("should inject dependencies in injectable object") {
+                    expect(injector.getObject(withType: InjectableClass.self)!.injectDependenciesCalled).to(beTrue())
+                }
+                
+                it("should return injectable ObjC object") {
+                    expect(injector.getObject(withType: InjectableObjCClass.self)).to(beAKindOf(InjectableObjCClass.self))
+                }
+                
+                it("should inject dependencies in injectable ObjC object") {
+                    expect(injector.getObject(withType: InjectableObjCClass.self)!.injectDependenciesCalled).to(beTrue())
+                }
+                
+                it("should return ObjC object") {
+                    expect(injector.getObject(withType: ObjCClass.self)).to(beAKindOf(ObjCClass.self))
+                }
+                
+            }
+            
+            
+            context("with bindings") {
+                
+                var objectConformingToProtocol: ClassConformingToProtocol?
+                var emptySwiftObject: EmptySwiftClass?
+                var injectableObject: InjectableClass?
+                var injectableObjCObject: InjectableObjCClass?
+                var objCObject: ObjCClass?
+                
+                beforeEach {
+                    objectConformingToProtocol = ClassConformingToProtocol()
+                    emptySwiftObject = EmptySwiftClass()
+                    injectableObject = InjectableClass(injector: injector)
+                    injectableObjCObject = InjectableObjCClass(injector: injector)
+                    objCObject = ObjCClass()
+                }
+                
+                context("object bindings") {
+                    
+                    beforeEach {
+                        bindings.bind(object: objectConformingToProtocol!, toType: EmptySwiftProtocol.self)
+                        bindings.bind(object: emptySwiftObject!, toType: EmptySwiftClass.self)
+                        bindings.bind(object: injectableObject!, toType: InjectableClass.self)
+                        bindings.bind(object: injectableObjCObject!, toType: InjectableObjCClass.self)
+                        bindings.bind(object: objCObject!, toType: ObjCClass.self)
+                    }
+                    
+                    it("should not have object conforming to protocol injected") {
+                        expect(injector.getObject(withType: EmptySwiftProtocol.self)).to(beIdenticalTo(objectConformingToProtocol))
+                    }
+                    
+                    it("should not have empty swift object injected") {
+                        expect(injector.getObject(withType: EmptySwiftClass.self)).to(beIdenticalTo(emptySwiftObject))
+                    }
+                    
+                    it("should have injectable object injected") {
+                        expect(injector.getObject(withType: InjectableClass.self)).to(beIdenticalTo(injectableObject))
+                    }
+                    
+                    it("should inject dependencies in injectable object") {
+                        expect(injector.getObject(withType: InjectableClass.self)!.injectDependenciesCalled).to(beFalse())
+                    }
+                    
+                    it("should have injectable ObjC object injected") {
+                        expect(injector.getObject(withType: InjectableObjCClass.self)).to(beIdenticalTo(injectableObjCObject))
+                    }
+                    
+                    it("should inject dependencies in injectable ObjC object") {
+                        expect(injector.getObject(withType: InjectableObjCClass.self)!.injectDependenciesCalled).to(beFalse())
+                    }
+                    
+                    it("should have ObjC object injected") {
+                        expect(injector.getObject(withType: ObjCClass.self)).to(beIdenticalTo(objCObject))
+                    }
+                    
+                }
+                
+                context("closure bindings") {
+                    
+                    beforeEach {
+                        injectableObject?.injectDependencies(injector: injector)
+                        injectableObjCObject?.injectDependencies(injector: injector)
+                        
+                        bindings.bind(type: EmptySwiftProtocol.self) { (injector: Injecting) -> AnyObject in
+                            return objectConformingToProtocol!
+                        }
+                        
+                        bindings.bind(type: EmptySwiftClass.self) { (injector: Injecting) -> AnyObject in
+                            return emptySwiftObject!
+                        }
+                        
+                        bindings.bind(type: InjectableClass.self) { (injector: Injecting) -> AnyObject in
+                            return injectableObject!
+                        }
+                        
+                        bindings.bind(type: InjectableObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            return injectableObjCObject!
+                        }
+                        
+                        bindings.bind(type: ObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            return objCObject!
+                        }
+                    }
+                    
+                    it("should not have object conforming to protocol injected") {
+                        expect(injector.getObject(withType: EmptySwiftProtocol.self)).to(beIdenticalTo(objectConformingToProtocol))
+                    }
+                    
+                    it("should not have empty swift object injected") {
+                        expect(injector.getObject(withType: EmptySwiftClass.self)).to(beIdenticalTo(emptySwiftObject))
+                    }
+                    
+                    it("should have injectable object injected") {
+                        expect(injector.getObject(withType: InjectableClass.self)).to(beIdenticalTo(injectableObject))
+                    }
+                    
+                    it("should inject dependencies in injectable object") {
+                        expect(injector.getObject(withType: InjectableClass.self)!.injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have injectable ObjC object injected") {
+                        expect(injector.getObject(withType: InjectableObjCClass.self)).to(beIdenticalTo(injectableObjCObject))
+                    }
+                    
+                    it("should inject dependencies in injectable ObjC object") {
+                        expect(injector.getObject(withType: InjectableObjCClass.self)!.injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have ObjC object injected") {
+                        expect(injector.getObject(withType: ObjCClass.self)).to(beIdenticalTo(objCObject))
+                    }
+                    
+                }
+                
+                context("closure bindings with new instances") {
+                    
+                    beforeEach {
+                        bindings.bind(type: EmptySwiftProtocol.self) { (injector: Injecting) -> AnyObject in
+                            return ClassConformingToProtocol()
+                        }
+                        
+                        bindings.bind(type: EmptySwiftClass.self) { (injector: Injecting) -> AnyObject in
+                            return EmptySwiftClass()
+                        }
+                        
+                        bindings.bind(type: InjectableClass.self) { (injector: Injecting) -> AnyObject in
+                            let injectableObject = InjectableClass()
+                            injectableObject.injectDependencies(injector: injector)
+                            return injectableObject
+                        }
+                        
+                        bindings.bind(type: InjectableObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            let injectableObjCObject = InjectableObjCClass()
+                            injectableObjCObject.injectDependencies(injector: injector)
+                            return injectableObjCObject
+                        }
+                        
+                        bindings.bind(type: ObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            return ObjCClass()
+                        }
+                    }
+                    
+                    it("should not have object conforming to protocol injected") {
+                        expect(injector.getObject(withType: EmptySwiftProtocol.self)).notTo(beNil())
+                    }
+                    
+                    it("should not have empty swift object injected") {
+                        expect(injector.getObject(withType: EmptySwiftClass.self)).notTo(beNil())
+                    }
+                    
+                    it("should have injectable object injected") {
+                        expect(injector.getObject(withType: InjectableClass.self)).notTo(beNil())
+                    }
+                    
+                    it("should inject dependencies in injectable object") {
+                        expect(injector.getObject(withType: InjectableClass.self)!.injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have injectable ObjC object injected") {
+                        expect(injector.getObject(withType: InjectableObjCClass.self)).to(beAKindOf(InjectableObjCClass.self))
+                    }
+                    
+                    it("should inject dependencies in injectable ObjC object") {
+                        expect(injector.getObject(withType: InjectableObjCClass.self)!.injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have ObjC object injected") {
+                        expect(injector.getObject(withType: ObjCClass.self)).to(beAKindOf(ObjCClass.self))
+                    }
+                    
+                }
+                
+            }
+            
+        }
+        
+        describe("subscript") {
+            
+            context("without any bindings") {
+                
+                it("should not return object conforming to protocol") {
+                    expect(injector[EmptySwiftProtocol.self]).to(beNil())
+                }
+                
+                it("should not return empty swift object") {
+                    expect(injector[EmptySwiftClass.self]).to(beNil())
+                }
+                
+                it("should return injectable object") {
+                    expect(injector[InjectableClass.self]).notTo(beNil())
+                }
+                
+                it("should inject dependencies in injectable object") {
+                    expect((injector[InjectableClass.self]! as! InjectableClass).injectDependenciesCalled).to(beTrue())
+                }
+                
+                it("should return injectable ObjC object") {
+                    expect(injector[InjectableObjCClass.self as Injectable.Type]).to(beAKindOf(InjectableObjCClass.self))
+                }
+                
+                it("should inject dependencies in injectable ObjC object") {
+                    expect((injector[InjectableObjCClass.self as Injectable.Type]! as! InjectableObjCClass).injectDependenciesCalled).to(beTrue())
+                }
+                
+                it("should return ObjC object") {
+                    expect(injector[ObjCClass.self]).to(beAKindOf(ObjCClass.self))
+                }
+                
+            }
+            
+            
+            context("with bindings") {
+                
+                var objectConformingToProtocol: ClassConformingToProtocol?
+                var emptySwiftObject: EmptySwiftClass?
+                var injectableObject: InjectableClass?
+                var injectableObjCObject: InjectableObjCClass?
+                var objCObject: ObjCClass?
+                
+                beforeEach {
+                    objectConformingToProtocol = ClassConformingToProtocol()
+                    emptySwiftObject = EmptySwiftClass()
+                    injectableObject = InjectableClass(injector: injector)
+                    injectableObjCObject = InjectableObjCClass(injector: injector)
+                    objCObject = ObjCClass()
+                }
+                
+                context("object bindings") {
+                    
+                    beforeEach {
+                        bindings.bind(object: objectConformingToProtocol!, toType: EmptySwiftProtocol.self)
+                        bindings.bind(object: emptySwiftObject!, toType: EmptySwiftClass.self)
+                        bindings.bind(object: injectableObject!, toType: InjectableClass.self)
+                        bindings.bind(object: injectableObjCObject!, toType: InjectableObjCClass.self)
+                        bindings.bind(object: objCObject!, toType: ObjCClass.self)
+                    }
+                    
+                    it("should not have object conforming to protocol injected") {
+                        expect(injector[EmptySwiftProtocol.self]).to(beIdenticalTo(objectConformingToProtocol))
+                    }
+                    
+                    it("should not have empty swift object injected") {
+                        expect(injector[EmptySwiftClass.self]).to(beIdenticalTo(emptySwiftObject))
+                    }
+                    
+                    it("should have injectable object injected") {
+                        expect(injector[InjectableClass.self]).to(beIdenticalTo(injectableObject))
+                    }
+                    
+                    it("should inject dependencies in injectable object") {
+                        expect((injector[InjectableClass.self]! as! InjectableClass).injectDependenciesCalled).to(beFalse())
+                    }
+                    
+                    it("should have injectable ObjC object injected") {
+                        expect(injector[InjectableObjCClass.self as Injectable.Type]).to(beIdenticalTo(injectableObjCObject))
+                    }
+                    
+                    it("should inject dependencies in injectable ObjC object") {
+                        expect((injector[InjectableObjCClass.self as Injectable.Type]! as! InjectableObjCClass).injectDependenciesCalled).to(beFalse())
+                    }
+                    
+                    it("should have ObjC object injected") {
+                        expect(injector[ObjCClass.self]).to(beIdenticalTo(objCObject))
+                    }
+                    
+                }
+                
+                context("closure bindings") {
+                    
+                    beforeEach {
+                        injectableObject?.injectDependencies(injector: injector)
+                        injectableObjCObject?.injectDependencies(injector: injector)
+                        
+                        bindings.bind(type: EmptySwiftProtocol.self) { (injector: Injecting) -> AnyObject in
+                            return objectConformingToProtocol!
+                        }
+                        
+                        bindings.bind(type: EmptySwiftClass.self) { (injector: Injecting) -> AnyObject in
+                            return emptySwiftObject!
+                        }
+                        
+                        bindings.bind(type: InjectableClass.self) { (injector: Injecting) -> AnyObject in
+                            return injectableObject!
+                        }
+                        
+                        bindings.bind(type: InjectableObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            return injectableObjCObject!
+                        }
+                        
+                        bindings.bind(type: ObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            return objCObject!
+                        }
+                    }
+                    
+                    it("should not have object conforming to protocol injected") {
+                        expect(injector[EmptySwiftProtocol.self]).to(beIdenticalTo(objectConformingToProtocol))
+                    }
+                    
+                    it("should not have empty swift object injected") {
+                        expect(injector[EmptySwiftClass.self]).to(beIdenticalTo(emptySwiftObject))
+                    }
+                    
+                    it("should have injectable object injected") {
+                        expect(injector[InjectableClass.self]).to(beIdenticalTo(injectableObject))
+                    }
+                    
+                    it("should inject dependencies in injectable object") {
+                        expect((injector[InjectableClass.self]! as! InjectableClass).injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have injectable ObjC object injected") {
+                        expect(injector[InjectableObjCClass.self as Injectable.Type]).to(beIdenticalTo(injectableObjCObject))
+                    }
+                    
+                    it("should inject dependencies in injectable ObjC object") {
+                        expect((injector[InjectableObjCClass.self as Injectable.Type]! as! InjectableObjCClass).injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have ObjC object injected") {
+                        expect(injector[ObjCClass.self]).to(beIdenticalTo(objCObject))
+                    }
+                    
+                }
+                
+                context("closure bindings with new instances") {
+                    
+                    beforeEach {
+                        bindings.bind(type: EmptySwiftProtocol.self) { (injector: Injecting) -> AnyObject in
+                            return ClassConformingToProtocol()
+                        }
+                        
+                        bindings.bind(type: EmptySwiftClass.self) { (injector: Injecting) -> AnyObject in
+                            return EmptySwiftClass()
+                        }
+                        
+                        bindings.bind(type: InjectableClass.self) { (injector: Injecting) -> AnyObject in
+                            let injectableObject = InjectableClass()
+                            injectableObject.injectDependencies(injector: injector)
+                            return injectableObject
+                        }
+                        
+                        bindings.bind(type: InjectableObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            let injectableObjCObject = InjectableObjCClass()
+                            injectableObjCObject.injectDependencies(injector: injector)
+                            return injectableObjCObject
+                        }
+                        
+                        bindings.bind(type: ObjCClass.self) { (injector: Injecting) -> AnyObject in
+                            return ObjCClass()
+                        }
+                    }
+                    
+                    it("should not have object conforming to protocol injected") {
+                        expect(injector[EmptySwiftProtocol.self]).notTo(beNil())
+                    }
+                    
+                    it("should not have empty swift object injected") {
+                        expect(injector[EmptySwiftClass.self]).notTo(beNil())
+                    }
+                    
+                    it("should have injectable object injected") {
+                        expect(injector[InjectableClass.self]).notTo(beNil())
+                    }
+                    
+                    it("should inject dependencies in injectable object") {
+                        expect((injector[InjectableClass.self]! as! InjectableClass).injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have injectable ObjC object injected") {
+                        expect(injector[InjectableObjCClass.self as Injectable.Type]).to(beAKindOf(InjectableObjCClass.self))
+                    }
+                    
+                    it("should inject dependencies in injectable ObjC object") {
+                        expect((injector[InjectableObjCClass.self as Injectable.Type]! as! InjectableObjCClass).injectDependenciesCalled).to(beTrue())
+                    }
+                    
+                    it("should have ObjC object injected") {
+                        expect(injector[ObjCClass.self]).to(beAKindOf(ObjCClass.self))
+                    }
+                    
+                }
+                
+            }
+            
+        }
 
-        describe("injectDependencies") {
+        describe("injecting dependencies in objects using injectDependencies(injector:) with the injector") {
 
             var objectWithDependencies: ClassWithDependencies!
 


### PR DESCRIPTION
* Added usage of subscripts for injecting dependencies
* Added usage of subscripts for getting and setting bindings

***Notice*** the `SwifjectorSpec.swift` diff is folded, as there were many additions. There are tests using both `getObject(withType:)` and `subscript(type:)` functions.